### PR TITLE
Support for using irc on Red Hat's OpenShift

### DIFF
--- a/irc/connection.py
+++ b/irc/connection.py
@@ -52,7 +52,8 @@ class Factory(object):
 
     def connect(self, server_address):
         sock = self.wrapper(socket.socket(self.family, socket.SOCK_STREAM))
-        sock.bind(self.bind_address)
+        if self.bind_address != ('', 0):
+            sock.bind(self.bind_address)
         sock.connect(server_address)
         return sock
     __call__ = connect


### PR DESCRIPTION
Red Hat's OpenShift PaaS cloud has SELinux and firewall rules in place which make 'binding' a client socket impossible.  Execution of something like `sock.bind (('127.11.210.3', 0))` will give a permission denied error.  If the socket is connected without first binding the socket the connection will be successful.  This modification checks whether a bind address has been specified, if not specified, it does not call bind on the created socket, in order to support OpenShift deployments.
