### PR TITLE
Remove references to buffer and logging modules from the docs

### DIFF
--- a/docs/irc.rst
+++ b/docs/irc.rst
@@ -19,14 +19,6 @@ irc.bot module
     :undoc-members:
     :show-inheritance:
 
-irc.buffer module
------------------
-
-.. automodule:: irc.buffer
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 irc.client module
 -----------------
 
@@ -79,14 +71,6 @@ irc.functools module
 --------------------
 
 .. automodule:: irc.functools
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-irc.logging module
-------------------
-
-.. automodule:: irc.logging
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
This should fix errors during `build_sphinx`. I still see this but I don't know how to fix it:

```
/home/sbraz/softs/irc/irc/server.py:docstring of irc.server.IRCClient:1: ERROR: Unknown target name: "handle".
```
