### PR TITLE
Fixes #119 per comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+15.0.5
+======
+* #119: Handle broken pipe exception in IRCClient _send() (server.py).
+
 15.0.4
 ======
 

--- a/irc/server.py
+++ b/irc/server.py
@@ -187,7 +187,7 @@ class IRCClient(socketserver.BaseRequestHandler):
         log.debug('to %s: %s', self.client_ident(), msg)
         try:
             self.request.send(msg.encode('utf-8') + b'\r\n')
-        except socket.error, e:
+        except socket.error as e:
             if e.errno == errno.EPIPE:
                 raise self.Disconnect()
             else:

--- a/irc/server.py
+++ b/irc/server.py
@@ -43,6 +43,7 @@ will ever be connected to by the public.
 from __future__ import print_function, absolute_import
 
 import argparse
+import errno
 import logging
 import socket
 import select
@@ -186,8 +187,11 @@ class IRCClient(socketserver.BaseRequestHandler):
         log.debug('to %s: %s', self.client_ident(), msg)
         try:
             self.request.send(msg.encode('utf-8') + b'\r\n')
-        except socket.error:
-            raise self.Disconnect()
+        except socket.error, e:
+            if e.errno == errno.EPIPE:
+                raise self.Disconnect()
+            else:
+                raise
 
     def handle_nick(self, params):
         """

--- a/irc/server.py
+++ b/irc/server.py
@@ -184,7 +184,10 @@ class IRCClient(socketserver.BaseRequestHandler):
 
     def _send(self, msg):
         log.debug('to %s: %s', self.client_ident(), msg)
-        self.request.send(msg.encode('utf-8') + b'\r\n')
+        try:
+            self.request.send(msg.encode('utf-8') + b'\r\n')
+        except socket.error:
+            raise self.Disconnect()
 
     def handle_nick(self, params):
         """


### PR DESCRIPTION
Hi @jaraco, I wrote this to handle cases such as where an IRC client might initiate a PING command and then immediately disconnect. Without this fix, the serve_forever() routine emits exception output on the console whenever this occurs. In my testing, this fix causes it to disconnect gracefully. Let me know if I'm missing anything. Thanks!