### PR TITLE
making AioConnection.connect a coroutine and other small fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,15 @@
+16.4
+====
+
+* #149: ``AioConnection.connect`` moved to coroutine, added
+  disconnect handling for AsyncIO.
+
 16.3
 ====
 
 * #140: Methods now use 'connection' and 'event' for parameter names.
-# #135 via #144: Added AsyncIO implementation.
+
+* #135 via #144: Added AsyncIO implementation.
 
 16.2.1
 ======

--- a/irc/tests/test_client_aio.py
+++ b/irc/tests/test_client_aio.py
@@ -18,7 +18,7 @@ def test_privmsg_sends_msg(create_connection_mock):
     # connect to dummy server
     loop = asyncio.get_event_loop()
     server = client_aio.AioReactor(loop=loop).server()
-    server.connect('foo', 6667, 'my_irc_nick')
+    loop.run_until_complete(server.connect('foo', 6667, 'my_irc_nick'))
     server.privmsg('#best-channel', 'You are great')
 
     mock_transport.write.assert_called_with(

--- a/scripts/irccat-aio.py
+++ b/scripts/irccat-aio.py
@@ -36,7 +36,6 @@ def get_lines():
 
 async def main_loop(connection):
     for line in itertools.takewhile(bool, get_lines()):
-        print(line)
         connection.privmsg(target, line)
 
         # Allow pause in the stdin loop to not block the asyncio event loop
@@ -70,9 +69,9 @@ def main():
     reactor = irc.client_aio.AioReactor(loop=loop)
 
     try:
-        c = reactor.server().connect(
+        c = loop.run_until_complete(reactor.server().connect(
             args.server, args.port, args.nickname, password=args.password
-        )
+        ))
     except irc.client.ServerConnectionError:
         print(sys.exc_info()[1])
         raise SystemExit(1)

--- a/scripts/irccat2-aio.py
+++ b/scripts/irccat2-aio.py
@@ -70,7 +70,6 @@ def main():
             args.server, args.port, args.nickname, password=args.password
         )
     except irc.client.ServerConnectionError as x:
-        print(x)
         sys.exit(1)
 
     try:


### PR DESCRIPTION
This PR is really more of a stopgap until @zinsserzh implements what he's planning in [this issue](https://github.com/jaraco/irc/issues/146), but I was butting up against some of the very limitations he was talking about and decided to roll out a patch to address them in the short term.  Specifically:

- As suggested, makes `AioConnection.connect` a coroutine, which allows for reconnecting after `loop.run_forever` has been called.  Since overwriting the `AioSimpleIRCClient.connect` function to call `loop.run_until_complete` was pretty easy, this change was actually minimally disruptive
- Adds a `AioConnection.disconnect` call to the IrcProtocol in the `connection_lost` function
- Cleans up the various `print` functions I stupidly left in last time