### PR TITLE
Allow configuring DCC listening IP and port

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,22 @@
   for loading version from metadata. Removes implicit dependency on
   setuptools and pkg_resources.
 
+* #155: ``SimpleIRCClient`` now has a ``dcc`` method for initiating
+  and associating a DCCConnection object with the client.
+  ``DCCConnection.listen`` now accepts a ``address`` parameter.
+  Deprecated ``SimpleIRCClient.dcc_listen`` and
+  ``SimpleIRCClient.dcc_connect`` in favor of the better separation
+  of concerns. Clients should replace::
+
+    client.dcc_connect(addr, port, type)
+    client.dcc_listen(type)
+
+  with::
+
+    client.dcc(type).connect(addr, port)
+    client.dcc(type).listen()
+
+
 17.0
 ====
 

--- a/irc/client.py
+++ b/irc/client.py
@@ -977,7 +977,7 @@ class DCCConnection(Connection):
         self.reactor._on_connect(self.socket)
         return self
 
-    def listen(self):
+    def listen(self, ip=None, port=None):
         """Wait for a connection/reconnection from a DCC peer.
 
         Returns the DCCConnection object.
@@ -992,7 +992,11 @@ class DCCConnection(Connection):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.passive = True
         try:
-            self.socket.bind((socket.gethostbyname(socket.gethostname()), 0))
+            if ip is None:
+                ip = socket.gethostbyname(socket.gethostname())
+            if port is None:
+                port = 0
+            self.socket.bind((ip, port))
             self.localaddress, self.localport = self.socket.getsockname()
             self.socket.listen(10)
         except socket.error as x:
@@ -1173,14 +1177,14 @@ class SimpleIRCClient:
         dcc.connect(address, port)
         return dcc
 
-    def dcc_listen(self, dcctype="chat"):
+    def dcc_listen(self, dcctype="chat", ip=None, port=None):
         """Listen for connections from a DCC peer.
 
         Returns a DCCConnection instance.
         """
         dcc = self.reactor.dcc(dcctype)
         self.dcc_connections.append(dcc)
-        dcc.listen()
+        dcc.listen(ip, port)
         return dcc
 
     def start(self):

--- a/irc/client.py
+++ b/irc/client.py
@@ -977,7 +977,7 @@ class DCCConnection(Connection):
         self.reactor._on_connect(self.socket)
         return self
 
-    def listen(self, ip=None, port=None):
+    def listen(self, addr=None):
         """Wait for a connection/reconnection from a DCC peer.
 
         Returns the DCCConnection object.
@@ -991,12 +991,9 @@ class DCCConnection(Connection):
         self.handlers = {}
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.passive = True
+        default_addr = socket.gethostbyname(socket.gethostname()), 0
         try:
-            if ip is None:
-                ip = socket.gethostbyname(socket.gethostname())
-            if port is None:
-                port = 0
-            self.socket.bind((ip, port))
+            self.socket.bind(addr or default_addr)
             self.localaddress, self.localport = self.socket.getsockname()
             self.socket.listen(10)
         except socket.error as x:
@@ -1177,15 +1174,14 @@ class SimpleIRCClient:
         dcc.connect(address, port)
         return dcc
 
-    def dcc_listen(self, dcctype="chat", ip=None, port=None):
+    def dcc_listen(self, dcctype="chat"):
         """Listen for connections from a DCC peer.
 
         Returns a DCCConnection instance.
         """
         dcc = self.reactor.dcc(dcctype)
         self.dcc_connections.append(dcc)
-        dcc.listen(ip, port)
-        return dcc
+        return dcc.listen()
 
     def start(self):
         """Start the IRC client."""

--- a/irc/client.py
+++ b/irc/client.py
@@ -1158,13 +1158,13 @@ class SimpleIRCClient:
         """Connect using the underlying connection"""
         self.connection.connect(*args, **kwargs)
 
-    def direct(self, type):
+    def dcc(self, *args, **kwargs):
         """Create and associate a new DCCConnection object.
 
         Use the returned object to listen for or connect to
         a DCC peer.
         """
-        dcc = self.reactor.dcc(type)
+        dcc = self.reactor.dcc(*args, **kwargs)
         self.dcc_connections.append(dcc)
         return dcc
 
@@ -1179,14 +1179,14 @@ class SimpleIRCClient:
 
         Returns a DCCConnection instance.
         """
-        return self.direct(dcctype).connect(address, port)
+        return self.dcc(dcctype).connect(address, port)
 
     def dcc_listen(self, dcctype="chat"):
         """Listen for connections from a DCC peer.
 
         Returns a DCCConnection instance.
         """
-        return self.direct(dcctype).listen()
+        return self.dcc(dcctype).listen()
 
     def start(self):
         """Start the IRC client."""

--- a/irc/client.py
+++ b/irc/client.py
@@ -60,6 +60,7 @@ import collections
 import functools
 import itertools
 import contextlib
+import warnings
 
 import jaraco.functools
 from jaraco.itertools import always_iterable, infinite_call
@@ -1179,6 +1180,7 @@ class SimpleIRCClient:
 
         Returns a DCCConnection instance.
         """
+        warnings.warn("Use self.dcc(type).connect()", DeprecationWarning)
         return self.dcc(dcctype).connect(address, port)
 
     def dcc_listen(self, dcctype="chat"):
@@ -1186,6 +1188,7 @@ class SimpleIRCClient:
 
         Returns a DCCConnection instance.
         """
+        warnings.warn("Use self.dcc(type).listen()", DeprecationWarning)
         return self.dcc(dcctype).listen()
 
     def start(self):

--- a/irc/client.py
+++ b/irc/client.py
@@ -1158,6 +1158,16 @@ class SimpleIRCClient:
         """Connect using the underlying connection"""
         self.connection.connect(*args, **kwargs)
 
+    def direct(self, type):
+        """Create and associate a new DCCConnection object.
+
+        Use the returned object to listen for or connect to
+        a DCC peer.
+        """
+        dcc = self.reactor.dcc(type)
+        self.dcc_connections.append(dcc)
+        return dcc
+
     def dcc_connect(self, address, port, dcctype="chat"):
         """Connect to a DCC peer.
 
@@ -1169,19 +1179,14 @@ class SimpleIRCClient:
 
         Returns a DCCConnection instance.
         """
-        dcc = self.reactor.dcc(dcctype)
-        self.dcc_connections.append(dcc)
-        dcc.connect(address, port)
-        return dcc
+        return self.direct(dcctype).connect(address, port)
 
     def dcc_listen(self, dcctype="chat"):
         """Listen for connections from a DCC peer.
 
         Returns a DCCConnection instance.
         """
-        dcc = self.reactor.dcc(dcctype)
-        self.dcc_connections.append(dcc)
-        return dcc.listen()
+        return self.direct(dcctype).listen()
 
     def start(self):
         """Start the IRC client."""


### PR DESCRIPTION
The library currently doesn't allow controlling which IP address or port are used for DCC. 
* The IP Address needs to be configurable, because sending a file via DCC over the Internet requires sending a public IP address, not the internal private IP.
* The port needs to be configurable, for IRC clients behind a firewall or NAT.