### PR TITLE
Schedule a reconnection check when starting the bot

### DIFF
--- a/irc/bot.py
+++ b/irc/bot.py
@@ -331,6 +331,7 @@ class SingleServerIRCBot(irc.client.SimpleIRCClient):
     def start(self):
         """Start the bot."""
         self._connect()
+        self.recon.run(self)
         super(SingleServerIRCBot, self).start()
 
 

--- a/scripts/irccat2-aio.py
+++ b/scripts/irccat2-aio.py
@@ -69,7 +69,7 @@ def main():
         c.connect(
             args.server, args.port, args.nickname, password=args.password
         )
-    except irc.client.ServerConnectionError as x:
+    except irc.client.ServerConnectionError:
         sys.exit(1)
 
     try:


### PR DESCRIPTION
If the first attept of connecting to the IRC server fails,
the scheduled reconnection check will ensure we start
executing the configured reconnection strategy.

Before this change no other connection attempts were
executed, given that the exception in `_connect` was ignored
and `_on_disconnect` was never triggered.