### PR TITLE
Add a connection factory for the async client

### DIFF
--- a/irc/connection.py
+++ b/irc/connection.py
@@ -49,3 +49,39 @@ class Factory:
         sock.connect(server_address)
         return sock
     __call__ = connect
+
+
+class AioFactory:
+    """
+    A class for creating async custom socket connections.
+
+    To create a simple connection:
+
+        server_address = ('localhost', 80)
+        Factory()(protocol_instance, server_address)
+
+    To create an SSL connection:
+
+        Factory(ssl=True)(protocol_instance, server_address)
+
+    To create an IPv6 connection:
+
+        Factory(ipv6=True)(protocol_instance, server_address)
+
+    Note that Factory doesn't save the state of the socket itself. The
+    caller must do that, as necessary. As a result, the Factory may be
+    re-used to create new connections with the same settings.
+
+    """
+
+    family = socket.AF_INET
+
+    def __init__(self, **kwargs):
+        self.connection_args = kwargs
+
+    def connect(self, protocol_instance, server_address):
+        return protocol_instance.loop.create_connection(
+            lambda: protocol_instance, *server_address,
+            **self.connection_args)
+
+    __call__ = connect


### PR DESCRIPTION
First of all, thanks a lot for this library!

This PR adds a factory for the async client, just as it's done for the sync client.

Using a factory lets users easily handle needed features. This doesn't fully solve #146 at all, but allows quick workarounds.

The default factory accepts random keywords during initialization, that will be given to `loop.create_connection`. The parameters are different from `Factory`, but they more or less cover the same features: IPv6 and SSL are now supported out-of-the-box for example.

This change shouldn't break any existing code using the library. It can be greatly improved (by improving consistency for example), but it's a start.