### PR TITLE
Escape asterisks in doc of **connect_params

### DIFF
--- a/irc/bot.py
+++ b/irc/bot.py
@@ -142,7 +142,7 @@ class SingleServerIRCBot(irc.client.SimpleIRCClient):
         dcc_connections -- A list of initiated/accepted DCC
             connections.
 
-        **connect_params -- parameters to pass through to the connect
+        \*\*connect_params -- parameters to pass through to the connect
             method.
     """
     def __init__(


### PR DESCRIPTION
This fixes the following warning:
irc/bot.py:docstring of irc.bot.SingleServerIRCBot:29: WARNING: Inline strong start-string without end-string.