### PR TITLE
Update client.py

### DIFF
--- a/irc/client.py
+++ b/irc/client.py
@@ -683,8 +683,14 @@ class ServerConnection(Connection):
         """
         Set a keepalive to occur every ``interval`` on this connection.
         """
-        pinger = functools.partial(self.ping, 'keep-alive')
-        self.reactor.scheduler.execute_every(period=interval, func=pinger)
+        self.reactor.scheduler.execute_every(period=interval, func=self.keepalive)
+
+    def keepalive(self):
+        """
+        Send a keepalive to the server (only when connected).
+        """
+        if self.connected:
+            self.ping('keep-alive')
 
 
 class PrioritizedHandler(collections.namedtuple('Base', ('priority', 'callback'))):


### PR DESCRIPTION
Currently, we encounter "ServerNotConnectedError: Not connected" error when the client tries to ping the server after the connection was closed. With this change, we only send a keepalive if we think we're connected. Otherwise, the client will crash if a keepalive is sent while disconnected.