### PR TITLE
fix: broken test on python >= 3.8.1

### DIFF
--- a/irc/connection.py
+++ b/irc/connection.py
@@ -75,8 +75,6 @@ class AioFactory:
 
     """
 
-    family = socket.AF_INET
-
     def __init__(self, **kwargs):
         self.connection_args = kwargs
 

--- a/scripts/irccat2-aio.py
+++ b/scripts/irccat2-aio.py
@@ -43,7 +43,7 @@ class AioIRCCat(irc.client_aio.AioSimpleIRCClient):
             self.connection.privmsg(self.target, line)
 
             # Allow pause in the stdin loop to not block asyncio loop
-            asyncio.sleep(0)
+            await asyncio.sleep(0)
         self.connection.quit("Using irc.client.py")
 
 


### PR DESCRIPTION
Closes #165 

Luckily the actual core functionality wasn't broken, but some change in python 3.8.1 broke the way the mocks were working in the offending test.  I used a fix that took some inspiration (with simplifications, since it's currently just a one off here) from  [aiohttp's](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/test_utils.py#L658-L668) extensive async testing.  Seems to be working normally in tox right now, at least locally.