### PR TITLE
Eliminate remaining client.VERSION{,_STRING} calls

### DIFF
--- a/irc/bot.py
+++ b/irc/bot.py
@@ -312,7 +312,9 @@ class SingleServerIRCBot(irc.client.SimpleIRCClient):
 
         Used when answering a CTCP VERSION request.
         """
-        return "Python irc.bot ({version})".format(version=irc.client.VERSION_STRING)
+        return "Python irc.bot (python{version})".format(
+            version=sys.version.split(" ")[0]
+        )
 
     def jump_server(self, msg="Changing servers"):
         """Connect to a new server, possibly disconnecting from the current.

--- a/irc/server.py
+++ b/irc/server.py
@@ -59,7 +59,7 @@ from jaraco.stream import buffer
 import irc.client
 from . import events
 
-SRV_WELCOME = "Welcome to {__name__} v{irc.client.VERSION}.".format(**locals())
+SRV_WELCOME = "Welcome to {__name__}.".format(**locals())
 
 log = logging.getLogger(__name__)
 

--- a/irc/tests/test_client.py
+++ b/irc/tests/test_client.py
@@ -5,14 +5,6 @@ import pytest
 import irc.client
 
 
-def test_version():
-    assert 'VERSION' in vars(irc.client)
-    assert 'VERSION_STRING' in vars(irc.client)
-    assert isinstance(irc.client.VERSION, tuple)
-    assert irc.client.VERSION, "No VERSION detected."
-    assert isinstance(irc.client.VERSION_STRING, str)
-
-
 @mock.patch('irc.connection.socket')
 def test_privmsg_sends_msg(socket_mod):
     server = irc.client.Reactor().server()

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ install_requires =
 	pytz
 	more_itertools
 	tempora>=1.6
-	importlib_metadata; python_version < "3.8"
 setup_requires = setuptools_scm[toml] >= 3.4.1
 
 [options.extras_require]


### PR DESCRIPTION
Commit 313620f removed irc.client.VERSION and
irc.client.VERSION_STRING while they were still used in irc.bot,
irc.server and unit testing. Get rid of those remaining instances,
and also remove the unit test routine which checked for the presence
of these variables since the module is no longer responsible for
them. Further clean up an unused reference to importlib_metadata in
the setup.cfg.

Fixes #174