### PR TITLE
Drop dependency on backports.unittest_mock, included in Python 3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,6 @@ testing =
 	pytest-cov
 	pytest-mypy
 
-	# local
-	backports.unittest_mock
-
 docs =
 	# upstream
 	sphinx


### PR DESCRIPTION
Hi Jason,
I'm removing the one reference to this now unused module.