### PR TITLE
Don't depend on backports.unittest_mock since Py<3.3 is unsupported

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ testing =
 	pytest-mypy
 
 	# local
-	backports.unittest_mock
 
 docs =
 	# upstream


### PR DESCRIPTION
Hey @jaraco,
Unless I'm missing something obvious, this is no longer required.