### PR TITLE
Fix default behavior of hanging without entering reconnection strategy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v20.1.0
+=======
+
+* #196: In irc.bot, avoid hanging idle when the first connection
+  attempt fails.
+
 v20.0.0
 =======
 

--- a/irc/bot.py
+++ b/irc/bot.py
@@ -200,7 +200,7 @@ class SingleServerIRCBot(irc.client.SimpleIRCClient):
                 ircname=self._realname,
                 **self.__connect_params,
             )
-        except irc.client.ServerConnectionError as e:
+        except irc.client.ServerConnectionError:
             self.connection._handle_event(irc.client.Event("disconnect", self.connection.server, "", [""]))
 
     def _on_disconnect(self, connection, event):

--- a/irc/bot.py
+++ b/irc/bot.py
@@ -193,7 +193,9 @@ class SingleServerIRCBot(irc.client.SimpleIRCClient):
                 **self.__connect_params,
             )
         except irc.client.ServerConnectionError:
-            self.connection._handle_event(irc.client.Event("disconnect", self.connection.server, "", [""]))
+            self.connection._handle_event(
+                irc.client.Event("disconnect", self.connection.server, "", [""])
+            )
 
     def _on_disconnect(self, connection, event):
         self.channels = IRCDict()

--- a/irc/bot.py
+++ b/irc/bot.py
@@ -149,9 +149,6 @@ class SingleServerIRCBot(irc.client.SimpleIRCClient):
             method.
     """
 
-
-    has_connected = False
-
     def __init__(
         self,
         server_list,
@@ -203,13 +200,8 @@ class SingleServerIRCBot(irc.client.SimpleIRCClient):
                 ircname=self._realname,
                 **self.__connect_params,
             )
-            self.has_connected = True
         except irc.client.ServerConnectionError as e:
-            if self.has_connected == False:
-                warnings.warn("Unable to connect to server. Check ip/port")
-                raise(e)
-            else:
-                warnings.warn("Failed to connect to server: {}".format(server.host))
+            self.connection._handle_event(irc.client.Event("disconnect", self.connection.server, "", [""]))
 
     def _on_disconnect(self, connection, event):
         self.channels = IRCDict()

--- a/irc/bot.py
+++ b/irc/bot.py
@@ -149,6 +149,9 @@ class SingleServerIRCBot(irc.client.SimpleIRCClient):
             method.
     """
 
+
+    has_connected = False
+
     def __init__(
         self,
         server_list,
@@ -200,8 +203,13 @@ class SingleServerIRCBot(irc.client.SimpleIRCClient):
                 ircname=self._realname,
                 **self.__connect_params,
             )
-        except irc.client.ServerConnectionError:
-            pass
+            self.has_connected = True
+        except irc.client.ServerConnectionError as e:
+            if self.has_connected == False:
+                warnings.warn("Unable to connect to server. Check ip/port")
+                raise(e)
+            else:
+                warnings.warn("Failed to connect to server: {}".format(server.host))
 
     def _on_disconnect(self, connection, event):
         self.channels = IRCDict()


### PR DESCRIPTION
This change throws an exception on the first connection attempt that way the user can check server info and there is some indication of failure.