### PR TITLE
Add support for SASL PLAIN authentication

### DIFF
--- a/irc/client.py
+++ b/irc/client.py
@@ -160,8 +160,9 @@ class ServerConnection(Connection):
         * server_address - The remote host/port of the server
         * connect_factory - A callable that takes the server address and
           returns a connection (with a socket interface)
-        * sasl_login - A string used to toggle sasl plain login. Password needs
-        to be set as well, and will be used for SASL, not PASS login.
+        * sasl_login - A string used to toggle sasl plain login.
+          Password needs to be set as well, and will be used for SASL,
+          not PASS login.
 
         This function can be called to reconnect a closed connection.
 

--- a/irc/events.py
+++ b/irc/events.py
@@ -166,6 +166,16 @@ numeric = {
     "492": "noservicehost",
     "501": "umodeunknownflag",
     "502": "usersdontmatch",
+    # IRCv3.1 SASL https://ircv3.net/specs/extensions/sasl-3.1
+    "900": "loggedin",
+    "901": "loggedout",
+    "902": "nicklocked",
+    "903": "saslsuccess",
+    "904": "saslfail",
+    "905": "sasltoolong",
+    "906": "saslaborted",
+    "907": "saslalready",
+    "908": "saslmechs",
 }
 
 codes = dict((v, k) for k, v in numeric.items())

--- a/irc/events.py
+++ b/irc/events.py
@@ -187,6 +187,7 @@ generated = [
     "disconnect",
     "ctcp",
     "ctcpreply",
+    "login_failed",
 ]
 
 protocol = [

--- a/newsfragments/195.feature.rst
+++ b/newsfragments/195.feature.rst
@@ -1,0 +1,1 @@
+Added support for SASL login.


### PR DESCRIPTION
This implements a minimal state machine to do the SASL PLAIN authentication dance.

It could have been done even simpler by sending all the commands and not checking for server capabilities, but I don't think it's being a good citizen.

It changes the ServerConnection api by adding a sasl_login argument, and reusing the old password argument, since I couldn't think of a usecase where both were needed. The SimpleIRCClient and SingleServerIRCBot can also pass this new argument.

A new "login_failed" generated event is added and is sent in some of the cases where the SASL login can fail. Note that there is no timeout on the state machine, so if the server does not send any of the expected commands, it will just stay active forever, potentially with the login failing.

It was tested on libera.chat with the cobe bot and seems to work reasonably well.

Fixes #195 