### PR TITLE
Add scripts/ to the excluded directories

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ exclude =
 	build*
 	dist*
 	docs*
+	scripts*
 	tests*
 
 [options.extras_require]


### PR DESCRIPTION
Otherwise setuptools will install it as a global "scripts" module, which doesn't seem intended.