### PR TITLE
Replace deprecated ssl.wrap_socket with SSLContext.wrap_socket

### DIFF
--- a/irc/connection.py
+++ b/irc/connection.py
@@ -20,13 +20,16 @@ class Factory:
 
     .. code-block:: python
 
+       context = ssl.create_default_context()
+       wrapper = functools.partial(context.wrap_socket, server_hostname=server_address)
        Factory(wrapper=ssl.wrap_socket)(server_address)
 
     To create an SSL connection with parameters to wrap_socket:
 
     .. code-block:: python
 
-       wrapper = functools.partial(ssl.wrap_socket, ssl_cert=get_cert())
+       context = ssl.create_default_context()
+       wrapper = functools.partial(context.wrap_socket, server_hostname=server_address, ssl_cert=get_cert())
        Factory(wrapper=wrapper)(server_address)
 
     To create an IPv6 connection:

--- a/newsfragments/216.feature.rst
+++ b/newsfragments/216.feature.rst
@@ -1,0 +1,1 @@
+Replace deprecated ssl.wrap_socket with SSLContext.wrap_socket and update examples in connection.py docs.

--- a/scripts/ssl-cat.py
+++ b/scripts/ssl-cat.py
@@ -11,6 +11,7 @@ import sys
 import ssl
 import argparse
 import itertools
+import functools
 
 import irc.client
 
@@ -60,7 +61,9 @@ def main():
     args = get_args()
     target = args.target
 
-    ssl_factory = irc.connection.Factory(wrapper=ssl.wrap_socket)
+    context = ssl.create_default_context()
+    wrapper = functools.partial(context.wrap_socket, server_hostname=args.server)
+    ssl_factory = irc.connection.Factory(wrapper=wrapper)
     reactor = irc.client.Reactor()
     try:
         c = reactor.server().connect(


### PR DESCRIPTION
* Update example code in ssl-cat.py
  * Replace deprecated ssl.wrap_socket with SSLContext.wrap_socket
* Update examples in connection.py docs

ssl.wrap_socket() was also removed in Python 3.12, so this makes ssl-cat.py work with 3.12.

I prefer this fix, but I also have a branch where I changed the library code to directly work with SSLContext.wrap_socket but it's a breaking change, since then ssl.wrap_socket() will no longer work: https://github.com/jaraco/irc/compare/main...StareInTheAir:irc-fork:feature/ssl-context-wrap-socket-lib
Please let me know if I should open a PR for that branch instead

This PR is backwards compatible since it's only client-side.

Resolves #216 