### PR TITLE
Fix SSL wrapper usage example in `Factory` docstring

### DIFF
--- a/irc/connection.py
+++ b/irc/connection.py
@@ -22,7 +22,7 @@ class Factory:
 
        context = ssl.create_default_context()
        wrapper = functools.partial(context.wrap_socket, server_hostname=server_address)
-       Factory(wrapper=ssl.wrap_socket)(server_address)
+       Factory(wrapper=wrapper)(server_address)
 
     To create an SSL connection with parameters to wrap_socket:
 


### PR DESCRIPTION
I believe a line in the SSL usage example has been missed in 5b745c377896d8e952b60aabbc47f2e5f1190574.