### PR TITLE
pyproject.toml: exclude the docs directory from packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,6 @@ doc = [
 ]
 
 [tool.setuptools.packages.find]
-exclude = ["scripts*"]
+exclude = ["docs*", "scripts*"]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Otherwise it would be installed as site-packages/docs/..., which is not correct.

Fixes #231