### PR TITLE
Fix for empty quit message

### DIFF
--- a/irc/client.py
+++ b/irc/client.py
@@ -411,7 +411,10 @@ class ServerConnection(Connection):
     def _handle_other(self, arguments, command, source, tags):
         target = None
         if command == "quit":
-            arguments = [arguments[0]]
+            if len(arguments) > 0:
+                arguments = [arguments[0]]
+            else:
+                arguments = [""]
         elif command == "ping":
             target = arguments[0]
         else:


### PR DESCRIPTION
When a quit occurs and there is no quit message len(arguments) is 0 (arguments is an empty list) and so this line in _handle_other "arguments = [arguments[0]]" causes an "IndexError". as i also posted here: https://github.com/jaraco/irc/issues/210