### PR TITLE
drop dependency on pytz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
 	"jaraco.logging",
 	"jaraco.functools>=1.20",
 	"jaraco.stream",
-	"pytz",
 	"more_itertools",
 	"tempora>=1.6",
 	'importlib_metadata; python_version < "3.8"',


### PR DESCRIPTION
It's not currently used in the code, it's also now deprecated as upstream has zoneinfo in the python stdlib